### PR TITLE
add Connection error when reading accel, gyro, mag

### DIFF
--- a/script/ak8963.py
+++ b/script/ak8963.py
@@ -68,10 +68,13 @@ class AK8963():
         self.asaz = self.bus.read_byte_data(self.address, ASAZ)
 
     def get_mag(self):
-        mx = self.read_raw_data(HXH, HXL)*self.mag_scale
-        my = self.read_raw_data(HYH, HYL)*self.mag_scale
-        mz = self.read_raw_data(HZH, HZL)*self.mag_scale
-        # print("raw mx my mz: ", mx, my, mz)
+        try:
+            mx = self.read_raw_data(HXH, HXL)*self.mag_scale
+            my = self.read_raw_data(HYH, HYL)*self.mag_scale
+            mz = self.read_raw_data(HZH, HZL)*self.mag_scale
+            # print("raw mx my mz: ", mx, my, mz)
+        except:
+            raise ConnectionError("I2C Connection Failure")
 
         # sensitivity adjustment
         mx = mx*(((self.asax-128)*0.5/128)+1)        

--- a/script/mpu6500.py
+++ b/script/mpu6500.py
@@ -189,10 +189,13 @@ class MPU6500():
 
     def get_accel(self):
         # MPU6500 accelerometer data in Earth’s reference (g)
-        ax = self.read_raw_data(ACCEL_XOUT_H, ACCEL_XOUT_L)*self.accel_scale
-        ay = self.read_raw_data(ACCEL_YOUT_H, ACCEL_YOUT_L)*self.accel_scale
-        az = self.read_raw_data(ACCEL_ZOUT_H, ACCEL_ZOUT_L)*self.accel_scale
-
+        try:
+            ax = self.read_raw_data(ACCEL_XOUT_H, ACCEL_XOUT_L)*self.accel_scale
+            ay = self.read_raw_data(ACCEL_YOUT_H, ACCEL_YOUT_L)*self.accel_scale
+            az = self.read_raw_data(ACCEL_ZOUT_H, ACCEL_ZOUT_L)*self.accel_scale
+        except:
+            raise ConnectionError("I2C Connection Failure")
+            
         accel = np.array([[ax],[ay],[az]])
         accel = accel-self.accel_offset
         ax = -accel[0][0]
@@ -204,9 +207,12 @@ class MPU6500():
         return ax, ay, az
 
     def get_gyro(self):
-        gx = self.read_raw_data(GYRO_XOUT_H, GYRO_XOUT_L)*self.gyro_scale
-        gy = self.read_raw_data(GYRO_YOUT_H, GYRO_YOUT_L)*self.gyro_scale
-        gz = self.read_raw_data(GYRO_ZOUT_H, GYRO_ZOUT_L)*self.gyro_scale
+        try:
+            gx = self.read_raw_data(GYRO_XOUT_H, GYRO_XOUT_L)*self.gyro_scale
+            gy = self.read_raw_data(GYRO_YOUT_H, GYRO_YOUT_L)*self.gyro_scale
+            gz = self.read_raw_data(GYRO_ZOUT_H, GYRO_ZOUT_L)*self.gyro_scale
+        except:
+            raise ConnectionError("I2C Connection Failure")
 
         gyro = np.array([[gx],[gy],[gz]])
         gyro = gyro-self.gyro_offset


### PR DESCRIPTION
When the I2C connection wire loosed, the program cannot read the data successfully. Therefore, I add up ConnectionError to remain the user for this error